### PR TITLE
Fix FIJI compatibility: add scijava-common annotation processor to pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> **GLKC Lab local build.** pom.xml updated for compatibility with current 
+> FIJI releases. Original plugin by Martinez et al. (2023) / EMBL.  
+> Original repository: https://github.com/embl-cba/microglia-morphometry
 # Microglia Morphometry
 
 <img src="./documentation/project-icon.png" width="300">

--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@
 
 A Fiji plugin for semi-automated segmentation, tracking and morphometric analysis of microglia cells in 2D images.
 
+---
+
+## Installation (GLKC Lab build)
+
+**Step 1 — Install MorpholibJ (required dependency)**
+
+1. Open FIJI
+2. Go to **Help > Update > Manage update sites**
+3. Find **IJPB-plugins**, tick the checkbox
+4. Click Close, then Apply changes, then restart FIJI
+
+**Step 2 — Install the plugin**
+
+1. Go to the [latest release](https://github.com/GLKC-Lab/microglia-morphometry/releases/latest)
+2. Download `microglia-morphometry-1_0_1-SNAPSHOT.jar` from the Assets section
+3. Copy the jar into your FIJI plugins folder:
+   - Windows: `Fiji.app\plugins\`
+   - macOS: right-click Fiji.app > Show Package Contents > `Contents/plugins/`
+   - Linux: `Fiji.app/plugins/`
+4. Restart FIJI
+5. The plugin appears under **Plugins > Microglia**
+
+📄 **[Download the full User Guide (PDF)](https://github.com/GLKC-Lab/microglia-morphometry/releases/latest)**
+
+---
+
 ## Citation
 
 If you use this plugin in your research, please cite the following:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,24 @@ A Fiji plugin for semi-automated segmentation, tracking and morphometric analysi
 
 ## Citation
 
-If you are using this plugin, please cite:
+If you use this plugin in your research, please cite the following:
 
-[Martinez A, Hériché JK, Calvo M, Tischer C, Otxoa-de-Amezaga A, Pedragosa J, Bosch A, Planas AM, Petegnief V. Characterization of microglia behaviour in healthy and pathological conditions with image analysis tools. Open Biol. 2023 Jan;13(1):220200. doi: 10.1098/rsob.220200. Epub 2023 Jan 11. PMID: 36629019; PMCID: PMC9832574.](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9832574/pdf/rsob.220200.pdf)
+**Original method and plugin:**
+Martinez A, Hérichè JK, Calvo M, Tischer C, Otxoa-de-Amezaga A, 
+Pedragosa J, Bosch A, Planas AM, Petegnief V. Characterization of 
+microglia behaviour in healthy and pathological conditions with image 
+analysis tools. Open Biol. 2023;13(1):220200. 
+doi: 10.1098/rsob.220200
+
+**Required dependency (MorpholibJ):**
+Legland D et al. MorpholibJ: integrated library and plugins for 
+mathematical morphology with ImageJ. Bioinformatics. 2016;32(22):3532-4. 
+doi: 10.1093/bioinformatics/btw413
+
+**This build:**
+If using this GLKC Lab local build specifically, please acknowledge:
+GL Kennedy-Clark, GLKC Lab local build for current FIJI compatibility.
+https://github.com/GLKC-Lab/microglia-morphometry
 
 ## Installation
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,29 @@
 			<version>5.4.2</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+   			<groupId>org.scijava</groupId>
+    			<artifactId>scijava-common</artifactId>
+		</dependency>
 	</dependencies>
+
+<build>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <annotationProcessorPaths>
+                    <path>
+                        <groupId>org.scijava</groupId>
+                        <artifactId>scijava-common</artifactId>
+                        <version>2.94.2</version>
+                    </path>
+                </annotationProcessorPaths>
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+
 </project>
 


### PR DESCRIPTION
The plugin fails to register its commands with FIJI on current releases because the SciJava plugin registration file (META-INF/json/org.scijava.plugin.Plugin) is not being generated at build time, preventing FIJI from discovering the commands.
Two changes to pom.xml address this:

Added scijava-common as an explicit dependency
Added a <build> block configuring maven-compiler-plugin to declare scijava-common in annotationProcessorPaths

After rebuilding with Maven, the registration file is present and all three commands appear correctly in FIJI. No changes to any Java source files, analysis code, or outputs. Build fix only.
Note: both changes were applied together prior to the successful rebuild. It is not possible to say with certainty which is strictly necessary — any guidance on this would be welcome.
Also noted: mcib3d-core 3.96.3 could not be resolved from imagej.public, Maven Central, or JitPack and required manual installation into the local Maven repository before the build could proceed. This may affect other users attempting to build from source.
Tested on: FIJI 2.16.0/1.54p, Java 21.0.7, Windows 11.